### PR TITLE
Use srcObject assigning through utils

### DIFF
--- a/client/js/localwall.js
+++ b/client/js/localwall.js
@@ -44,7 +44,7 @@
 
   function onDesktopStream(stream) {
     var video = document.querySelector("#desktop");
-    video.src = window.URL.createObjectURL(stream);
+    setVideoStream(video, stream);
   }
 
   navigator.getUserMedia(webcamOptions, onWebcamStream, function(e) {
@@ -53,7 +53,7 @@
 
   function onWebcamStream(stream){
     var video = document.querySelector("#webcam");
-    video.src = window.URL.createObjectURL(stream);
+    setVideoStream(video, stream);
   };
 
 })();

--- a/client/js/remotewall.js
+++ b/client/js/remotewall.js
@@ -34,7 +34,7 @@
 
     navigator.getUserMedia(videoOptions, function (stream) {
       localVideoStream = stream;
-      localVideoElem.src = URL.createObjectURL(localVideoStream);
+      setVideoStream(localVideoElem, localVideoStream);
       createAndSendAnswer();
     }, function (error) { console.log(error); });
   }
@@ -47,7 +47,7 @@
       localVideoElem.classList.add('hide');
     }
     if (remoteVideoElem) {
-      remoteVideoElem.src = URL.createObjectURL(localVideoStream);
+      setVideoStream(remoteVideoElem, localVideoStream);
     }
   }
 
@@ -85,9 +85,9 @@
   }
 
   function onAddStreamHandler (e) {
-    remoteVideoElem.src = URL.createObjectURL(e.stream);
+    setVideoStream(remoteVideoElem, e.stream);
     if (localVideoStream) {
-      localVideoElem.src = URL.createObjectURL(localVideoStream);
+      setVideoStream(localVideoElem, localVideoStream);
       localVideoElem.classList.remove('hide');
     }
   }

--- a/client/js/sharer.js
+++ b/client/js/sharer.js
@@ -67,7 +67,8 @@
 
     navigator.getUserMedia(desktopOptions, function (stream) {
       localVideoStream = stream;
-      localVideoElem.src = URL.createObjectURL(localVideoStream);
+      setVideoStream(localVideoElem, localVideoStream);
+
       peerConn.addStream(localVideoStream);
       createAndSendOffer();
     }, function (error) { console.log(error); });

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -1,0 +1,8 @@
+function setVideoStream($video, stream){
+  // ref: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject
+  try {
+    $video.srcObject = stream;
+  } catch (error) {
+    $video.src = window.URL.createObjectURL(stream);
+  }
+}

--- a/client/localwall.html
+++ b/client/localwall.html
@@ -21,6 +21,7 @@
       </div>
     </main>
     <footer></footer>
+    <script type="text/javascript" src="./js/utils.js"></script>
     <script type="text/javascript" src="./js/localwall.js"></script>
   </body>
 </html>

--- a/client/remotewall.html
+++ b/client/remotewall.html
@@ -22,6 +22,7 @@
     </main>
     <footer></footer>
     <script type="text/javascript" src="./js/config.js"></script>
+    <script type="text/javascript" src="./js/utils.js"></script>
     <script type="text/javascript" src="./js/remotewall.js"></script>
   </body>
 </html>

--- a/client/sharer.html
+++ b/client/sharer.html
@@ -16,6 +16,7 @@
     </main>
     <footer></footer>
     <script type="text/javascript" src="./js/config.js"></script>
+    <script type="text/javascript" src="./js/utils.js"></script>
     <script type="text/javascript" src="./js/sharer.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Cool work @neokore.

It looks like video.src doesn't work now in modern browsers, but video.srcObject (tested in Firefox developer edition).

In my tests 'Go standalone' & 'Share this screen' work fine. I coundn't make 'Reve remote shared screen' work but it can be a configuration issue in my side.